### PR TITLE
:nowait and :disable keys for BSHost

### DIFF
--- a/onebootstrap
+++ b/onebootstrap
@@ -374,10 +374,13 @@ class BSHost < BS
 
         rc = @resource.allocate(*args)
 
-       error(rc) if OpenNebula.is_error?(rc)
+        return error(rc) if OpenNebula.is_error?(rc)
+
+        @resource.disable if @hash["disable"]
     end
 
     def wait
+        return true if @hash["nowait"]
         wait_states(["MONITORING_MONITORED", "MONITORED"])
     end
 end


### PR DESCRIPTION
Add :nowait and :disable keys to BSHost, if defined will not wait to MONITOR and will disable the host, respectively