### PR TITLE
Support nowait on datastore

### DIFF
--- a/onebootstrap
+++ b/onebootstrap
@@ -503,7 +503,9 @@ class BSDatastore < BS
     def wait
         return false if !wait_states(["READY"])
 
-        resource_wait {|res| res["TOTAL_MB"].to_s != "0" }
+        unless @hash["nowait"]
+            resource_wait {|res| res["TOTAL_MB"].to_s != "0" }
+        end
     end
 end
 


### PR DESCRIPTION
The datastore size monitoring loop may be skipped (e.g. for non-shared system DS).